### PR TITLE
Fixed Invalid calling object for IE 10 & 11

### DIFF
--- a/json_query.js
+++ b/json_query.js
@@ -64,8 +64,11 @@
     if(val == null){
       return 'String';
     }
-
-    var type = toString.call(val).slice(8, -1);
+    
+	/*@info Fix for IE 10 & 11
+	 *@bug Invalid calling object
+	 */
+    var type = Object.prototype.toString.call(val).slice(8, -1);
 
     if(type == 'String' && val.match(/\d{4}-\d{2}-\d{2}/)){
       return 'Date';


### PR DESCRIPTION
In IE 10 & 11 by just referencing toString.call() will return a Invalid calling object error.
So it can be override by referencing the Object.prototype method.
